### PR TITLE
first realisation of stack

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,26 @@
+cmake_minimum_required(VERSION 3.28)
+project(stack_duplicate_fifo)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+find_package(GTest)
+if (NOT ${GTest_FOUND})
+    include(gtest/gtest.cmake)
+endif()
+
+enable_testing()
+add_executable(stack_duplicate_fifo_test
+        stack_duplicate_fifo.h test.cpp)
+target_link_libraries(stack_duplicate_fifo_test
+        GTest::gtest
+        GTest::gtest_main
+        GTest::gmock
+        GTest::gmock_main
+)
+
+include(GoogleTest)
+gtest_discover_tests(stack_duplicate_fifo_test)
+
+add_executable(stack_duplicate_fifo
+        stack_duplicate_fifo.h main.cpp)

--- a/gtest/gtest.cmake
+++ b/gtest/gtest.cmake
@@ -1,0 +1,9 @@
+include(FetchContent)
+FetchContent_Declare(
+        googletest
+        # Specify the commit you depend on and update it regularly.
+        URL https://github.com/google/googletest/archive/refs/tags/v1.16.0.zip
+)
+# For Windows: Prevent overriding the parent project's compiler/linker settings
+set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+FetchContent_MakeAvailable(googletest)

--- a/main.cpp
+++ b/main.cpp
@@ -1,0 +1,24 @@
+#include <cassert>
+
+#include "stack_duplicate_fifo.h"
+
+
+int main()
+{
+    StackDuplicateFifo<int> stack;
+    stack.Push(5);
+    assert(stack.Top() == 5);
+    stack.Push(3);
+    assert(stack.Top() == 3);
+    stack.Push(2);
+    assert(stack.Top() == 2);
+    stack.Pop();
+    assert(stack.Top() == 3);
+    stack.Push(5);
+    assert(stack.Top() == 5);
+    stack.Pop();
+    assert(stack.Top() == 5);
+    stack.Pop();
+    assert(stack.Top() == 3);
+    return 0;
+}

--- a/stack_duplicate_fifo.h
+++ b/stack_duplicate_fifo.h
@@ -24,6 +24,9 @@ public:
 
     StackDuplicateFifo& operator=(StackDuplicateFifo&& other)
     {
+        if (this == &other) {
+            return *this;
+        }
         m_stack = std::move(other.m_stack);
         m_valueToCount = std::move(other.m_valueToCount);
         m_size = other.m_size;
@@ -31,12 +34,12 @@ public:
         return *this;
     }
 
-    T& Top() noexcept
+    T& Top()
     {
         RemoveInvalid();
         return m_stack.back();
     }
-    const T& Top() const noexcept
+    const T& Top() const
     {
         RemoveInvalid();
         return m_stack.back();
@@ -81,7 +84,10 @@ public:
             m_valueToCount.erase(it);
             m_stack.pop_back();
         }
-        --m_size;
+        if (--m_size == 0 && !m_stack.empty())
+        {
+            m_stack.clear();
+        }
     }
 
 private:
@@ -91,7 +97,7 @@ private:
 
     void RemoveInvalid()
     {
-        while (!m_valueToCount.count(m_stack.back()) && !m_stack.empty())
+        while (!m_stack.empty() && !m_valueToCount.count(m_stack.back()))
         {
             m_stack.pop_back();
         }

--- a/stack_duplicate_fifo.h
+++ b/stack_duplicate_fifo.h
@@ -83,7 +83,7 @@ public:
 
     void Pop()
     {
-        if (m_stack.size() == 0)
+        if (m_stack.empty())
         {
             return;
         }

--- a/stack_duplicate_fifo.h
+++ b/stack_duplicate_fifo.h
@@ -1,0 +1,106 @@
+#pragma once
+
+#include <deque>
+#include <iostream>
+#include <queue>
+#include <unordered_map>
+
+
+template <typename T>
+class StackDuplicateFifo
+{
+public:
+    StackDuplicateFifo() = default;
+    StackDuplicateFifo(const StackDuplicateFifo&) = default;
+    StackDuplicateFifo& operator=(const StackDuplicateFifo&) = default;
+
+    StackDuplicateFifo(StackDuplicateFifo&& other) :
+        m_stack(std::move(other.m_stack)),
+        m_valueToCount(std::move(other.m_valueToCount)),
+        m_size(other.m_size)
+    {
+        other.Clear();
+    }
+
+    StackDuplicateFifo& operator=(StackDuplicateFifo&& other)
+    {
+        m_stack = std::move(other.m_stack);
+        m_valueToCount = std::move(other.m_valueToCount);
+        m_size = other.m_size;
+        other.Clear();
+        return *this;
+    }
+
+    T& Top() noexcept
+    {
+        RemoveInvalid();
+        return m_stack.back();
+    }
+    const T& Top() const noexcept
+    {
+        RemoveInvalid();
+        return m_stack.back();
+    }
+
+    bool Empty() const noexcept
+    {
+        return m_size == 0;
+    }
+    size_t Size() const noexcept
+    {
+        return m_size;
+    }
+
+    void Push(const T& value)
+    {
+        m_stack.push_back(value);
+        ++m_valueToCount[m_stack.back()];
+        ++m_size;
+    }
+    void Push(T&& value)
+    {
+        m_stack.push_back(std::move(value));
+        ++m_valueToCount[m_stack.back()];
+        ++m_size;
+    }
+
+    void Pop()
+    {
+        if (m_size == 0)
+        {
+            return;
+        }
+        auto it = m_valueToCount.find(m_stack.back());
+        while (it == m_valueToCount.end())
+        {
+            m_stack.pop_back();
+            it = m_valueToCount.find(m_stack.back());
+        }
+        if (--(it->second) == 0)
+        {
+            m_valueToCount.erase(it);
+            m_stack.pop_back();
+        }
+        --m_size;
+    }
+
+private:
+    std::deque<T> m_stack;
+    std::unordered_map<T, size_t> m_valueToCount;
+    size_t m_size = 0;
+
+    void RemoveInvalid()
+    {
+        while (!m_valueToCount.count(m_stack.back()) && !m_stack.empty())
+        {
+            m_stack.pop_back();
+        }
+    }
+
+    void Clear()
+    {
+        m_size = 0;
+        m_stack.clear();
+        m_valueToCount.clear();
+    }
+};

--- a/stack_duplicate_fifo.h
+++ b/stack_duplicate_fifo.h
@@ -2,111 +2,112 @@
 
 #include <deque>
 #include <iostream>
+#include <list>
 #include <queue>
 #include <unordered_map>
-
 
 template <typename T>
 class StackDuplicateFifo
 {
 public:
     StackDuplicateFifo() = default;
-    StackDuplicateFifo(const StackDuplicateFifo&) = default;
-    StackDuplicateFifo& operator=(const StackDuplicateFifo&) = default;
+
+    StackDuplicateFifo(const StackDuplicateFifo& other) : m_stack(other.m_stack)
+    {
+        for (auto it = m_stack.begin(), it_end = m_stack.end(); it != it_end; ++it)
+        {
+            m_valueToDuplicateIter[*it].push(it);
+        }
+    }
+
+    StackDuplicateFifo& operator=(const StackDuplicateFifo& other)
+    {
+        if (this == &other)
+        {
+            return *this;
+        }
+        StackDuplicateFifo tmp(other);
+        this->Swap(tmp);
+        return *this;
+    }
 
     StackDuplicateFifo(StackDuplicateFifo&& other) :
         m_stack(std::move(other.m_stack)),
-        m_valueToCount(std::move(other.m_valueToCount)),
-        m_size(other.m_size)
+        m_valueToDuplicateIter(std::move(other.m_valueToDuplicateIter))
     {
         other.Clear();
     }
 
     StackDuplicateFifo& operator=(StackDuplicateFifo&& other)
     {
-        if (this == &other) {
+        if (this == &other)
+        {
             return *this;
         }
         m_stack = std::move(other.m_stack);
-        m_valueToCount = std::move(other.m_valueToCount);
-        m_size = other.m_size;
+        m_valueToDuplicateIter = std::move(other.m_valueToDuplicateIter);
         other.Clear();
         return *this;
     }
 
+    ~StackDuplicateFifo() = default;
+
     T& Top()
     {
-        RemoveInvalid();
         return m_stack.back();
     }
     const T& Top() const
     {
-        RemoveInvalid();
         return m_stack.back();
     }
 
     bool Empty() const noexcept
     {
-        return m_size == 0;
+        return m_stack.empty();
     }
     size_t Size() const noexcept
     {
-        return m_size;
+        return m_stack.size();
     }
 
     void Push(const T& value)
     {
         m_stack.push_back(value);
-        ++m_valueToCount[m_stack.back()];
-        ++m_size;
+        m_valueToDuplicateIter[m_stack.back()].push(--m_stack.end());
     }
     void Push(T&& value)
     {
         m_stack.push_back(std::move(value));
-        ++m_valueToCount[m_stack.back()];
-        ++m_size;
+        m_valueToDuplicateIter[m_stack.back()].push(--m_stack.end());
     }
 
     void Pop()
     {
-        if (m_size == 0)
+        if (m_stack.size() == 0)
         {
             return;
         }
-        auto it = m_valueToCount.find(m_stack.back());
-        while (it == m_valueToCount.end())
+        auto it = m_valueToDuplicateIter.find(m_stack.back());
+        m_stack.erase(it->second.front());
+        it->second.pop();
+        if (it->second.empty())
         {
-            m_stack.pop_back();
-            it = m_valueToCount.find(m_stack.back());
-        }
-        if (--(it->second) == 0)
-        {
-            m_valueToCount.erase(it);
-            m_stack.pop_back();
-        }
-        if (--m_size == 0 && !m_stack.empty())
-        {
-            m_stack.clear();
+            m_valueToDuplicateIter.erase(it);
         }
     }
-
 private:
-    std::deque<T> m_stack;
-    std::unordered_map<T, size_t> m_valueToCount;
-    size_t m_size = 0;
+    std::list<T> m_stack;
+    std::unordered_map<T, std::queue<typename std::list<T>::iterator> > m_valueToDuplicateIter;
 
-    void RemoveInvalid()
+    void Swap(StackDuplicateFifo& other)
     {
-        while (!m_stack.empty() && !m_valueToCount.count(m_stack.back()))
-        {
-            m_stack.pop_back();
-        }
+        std::swap(m_stack, other.m_stack);
+        std::swap(m_valueToDuplicateIter, other.m_valueToDuplicateIter);
     }
 
     void Clear()
     {
-        m_size = 0;
         m_stack.clear();
-        m_valueToCount.clear();
+        m_valueToDuplicateIter.clear();
     }
 };

--- a/test.cpp
+++ b/test.cpp
@@ -1,0 +1,312 @@
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+
+#include <list>
+#include <random>
+#include <stack>
+#include <vector>
+
+#include "stack_duplicate_fifo.h"
+
+
+TEST(BasicTest, DefaultCtor)
+{
+    StackDuplicateFifo<int> stack;
+    EXPECT_EQ(stack.Size(), 0);
+    EXPECT_EQ(stack.Empty(), true);
+}
+
+TEST(BasicTest, EmptyPop)
+{
+    StackDuplicateFifo<int> stack;
+    stack.Pop();
+    stack.Pop();
+}
+
+TEST(BasicTest, PushPop)
+{
+    StackDuplicateFifo<int> stack;
+    stack.Push(5);
+    EXPECT_EQ(stack.Top(), 5);
+    EXPECT_EQ(stack.Size(), 1);
+    EXPECT_EQ(stack.Empty(), false);
+    stack.Pop();
+    EXPECT_EQ(stack.Size(), 0);
+    EXPECT_EQ(stack.Empty(), true);
+}
+
+TEST(BasicTest, CopyCtor)
+{
+    StackDuplicateFifo<int> stack;
+    for (int i = 0; i < 5; ++i)
+    {
+        stack.Push(i);
+    }
+    StackDuplicateFifo<int> copy_stack = stack;
+    EXPECT_EQ(stack.Size(), 5);
+    EXPECT_EQ(stack.Empty(), false);
+
+    while (!stack.Empty())
+    {
+        EXPECT_EQ(stack.Size(), copy_stack.Size());
+        EXPECT_EQ(stack.Top(), copy_stack.Top());
+        stack.Pop();
+        copy_stack.Pop();
+    }
+}
+
+TEST(BasicTest, CopyAssignment)
+{
+    {
+        StackDuplicateFifo<int> a;
+        for (int i = 0; i < 5; ++i)
+        {
+            a.Push(i);
+        }
+        StackDuplicateFifo<int> b;
+        a = b;
+        EXPECT_EQ(a.Size(), 0);
+        EXPECT_EQ(a.Empty(), true);
+    }
+    {
+        StackDuplicateFifo<int> stack;
+        for (int i = 0; i < 5; ++i)
+        {
+            stack.Push(i);
+        }
+        StackDuplicateFifo<int> copy_stack;
+        copy_stack = stack;
+        EXPECT_EQ(stack.Size(), 5);
+        EXPECT_EQ(stack.Empty(), false);
+
+        while (!stack.Empty())
+        {
+            EXPECT_EQ(stack.Size(), copy_stack.Size());
+            EXPECT_EQ(stack.Top(), copy_stack.Top());
+            stack.Pop();
+            copy_stack.Pop();
+        }
+    }
+}
+
+TEST(BasicTest, ValidAfterMove)
+{
+    StackDuplicateFifo<int> stack;
+    for (int i = 0; i < 5; ++i)
+    {
+        stack.Push(i);
+    }
+    StackDuplicateFifo<int> copy_stack = std::move(stack);
+    //    stack.Clear();
+    EXPECT_EQ(copy_stack.Size(), 5);
+    EXPECT_EQ(copy_stack.Empty(), false);
+
+    for (int i = 0; i < 5; ++i)
+    {
+        stack.Push(i);
+    }
+    while (!copy_stack.Empty())
+    {
+        EXPECT_EQ(stack.Size(), copy_stack.Size());
+        EXPECT_EQ(stack.Top(), copy_stack.Top());
+        stack.Pop();
+        copy_stack.Pop();
+    }
+}
+
+TEST(BasicTest, StackBehaviour)
+{
+    std::stack<int> expected;
+    for (int i = 0; i < 100; ++i)
+    {
+        expected.push(i);
+    }
+
+    StackDuplicateFifo<int> stack;
+    for (int i = 0; i < 100; ++i)
+    {
+        stack.Push(i);
+    }
+
+    while (!expected.empty())
+    {
+        EXPECT_EQ(stack.Size(), expected.size());
+        EXPECT_EQ(stack.Top(), expected.top());
+        stack.Pop();
+        expected.pop();
+    }
+    EXPECT_EQ(stack.Size(), expected.size());
+    EXPECT_EQ(stack.Empty(), expected.empty());
+}
+
+TEST(StackDuplicateFifoBehaviour, SimpleTest)
+{
+    StackDuplicateFifo<int> stack;
+    stack.Push(5);
+    ASSERT_EQ(stack.Top(), 5);
+    stack.Push(3);
+    ASSERT_EQ(stack.Top(), 3);
+    stack.Push(2);
+    ASSERT_EQ(stack.Top(), 2);
+    stack.Pop();
+    ASSERT_EQ(stack.Top(), 3);
+    stack.Push(5);
+    ASSERT_EQ(stack.Top(), 5);
+    stack.Pop();
+    ASSERT_EQ(stack.Top(), 5);
+    stack.Pop();
+    ASSERT_EQ(stack.Top(), 3);
+    stack.Pop();
+    ASSERT_EQ(stack.Size(), 0);
+    ASSERT_EQ(stack.Empty(), true);
+}
+
+TEST(StackDuplicateFifoBehaviour, OnlyEqualElem)
+{
+    std::vector<int> expected(5, 7);
+    StackDuplicateFifo<int> stack;
+    for (int i = 0; i < expected.size(); ++i)
+    {
+        stack.Push(7);
+    }
+
+    while (!expected.empty())
+    {
+        EXPECT_EQ(stack.Size(), expected.size());
+        EXPECT_EQ(stack.Top(), expected.back());
+        stack.Pop();
+        expected.pop_back();
+    }
+    EXPECT_EQ(stack.Size(), expected.size());
+    EXPECT_EQ(stack.Empty(), expected.empty());
+}
+
+TEST(StackDuplicateFifoBehaviour, DifferentElem)
+{
+    std::vector<int> expected = {0, 0, 0, 1, 1, 1, 2, 2, 2};
+    StackDuplicateFifo<int> stack;
+    for (int i = 0; i < expected.size(); ++i)
+    {
+        stack.Push(i % 3);
+    }
+
+    while (!expected.empty())
+    {
+        EXPECT_EQ(stack.Size(), expected.size());
+        EXPECT_EQ(stack.Top(), expected.back());
+        stack.Pop();
+        expected.pop_back();
+    }
+    EXPECT_EQ(stack.Size(), expected.size());
+    EXPECT_EQ(stack.Empty(), expected.empty());
+}
+
+template <typename T>
+class SlowStackDuplicateFifo
+{
+public:
+    T& Top() noexcept
+    {
+        return m_stack.back();
+    }
+    const T& Top() const noexcept
+    {
+        return m_stack.back();
+    }
+
+    bool Empty() const noexcept
+    {
+        return m_stack.empty();
+    }
+    size_t Size() const noexcept
+    {
+        return m_stack.size();
+    }
+
+    void Push(const T& value)
+    {
+        m_stack.push_back(value);
+    }
+    void Push(T&& value)
+    {
+        m_stack.push_back(std::move(value));
+    }
+
+    // complexity: O(n)
+    void Pop()
+    {
+        for (auto it = m_stack.begin(), it_end = m_stack.end(); it != it_end; ++it)
+        {
+            if (*it == m_stack.back())
+            {
+                m_stack.erase(it);
+                return;
+            }
+        }
+    }
+private:
+    std::list<T> m_stack;
+};
+
+TEST(StackDuplicateFifoBehaviour, RandomFilled)
+{
+    constexpr int num_iterations = 10'000;
+    std::mt19937 gen(735'675);
+    std::uniform_int_distribution dist(1, 1000);
+
+    StackDuplicateFifo<int> stack;
+    SlowStackDuplicateFifo<int> expected;
+
+    for (int i = 0; i < num_iterations; ++i) {
+        auto value = dist(gen);
+        stack.Push(value);
+        expected.Push(value);
+    }
+    EXPECT_EQ(stack.Size(), expected.Size());
+    EXPECT_EQ(stack.Top(), expected.Top());
+
+    while (!expected.Empty()) {
+        EXPECT_EQ(stack.Size(), expected.Size());
+        EXPECT_EQ(stack.Top(), expected.Top());
+        stack.Pop();
+        expected.Pop();
+    }
+    EXPECT_EQ(stack.Size(), expected.Size());
+    EXPECT_EQ(stack.Empty(), expected.Empty());
+}
+
+TEST(StackDuplicateFifoBehaviour, Stress)
+{
+    constexpr int num_iterations = 100'000;
+    std::mt19937 gen(735'675);
+    std::uniform_int_distribution dist(1, 100);
+
+    StackDuplicateFifo<int> stack;
+    SlowStackDuplicateFifo<int> expected;
+
+    for (int i = 0; i < num_iterations; ++i) {
+        auto code = dist(gen);
+        if (code > 70 && !expected.Empty())
+        {
+            EXPECT_EQ(stack.Top(), expected.Top());
+            stack.Pop();
+            expected.Pop();
+        }
+        else
+        {
+            stack.Push(code);
+            expected.Push(code);
+        }
+    }
+    EXPECT_EQ(stack.Size(), expected.Size());
+    EXPECT_EQ(stack.Top(), expected.Top());
+
+    while (!expected.Empty()) {
+        EXPECT_EQ(stack.Size(), expected.Size());
+        EXPECT_EQ(stack.Top(), expected.Top());
+        stack.Pop();
+        expected.Pop();
+    }
+    EXPECT_EQ(stack.Size(), expected.Size());
+    EXPECT_EQ(stack.Empty(), expected.Empty());
+}

--- a/test.cpp
+++ b/test.cpp
@@ -45,6 +45,8 @@ TEST(BasicTest, CopyCtor)
     StackDuplicateFifo<int> copy_stack = stack;
     EXPECT_EQ(stack.Size(), 5);
     EXPECT_EQ(stack.Empty(), false);
+    EXPECT_EQ(copy_stack.Size(), 5);
+    EXPECT_EQ(copy_stack.Empty(), false);
 
     while (!stack.Empty())
     {
@@ -85,6 +87,37 @@ TEST(BasicTest, CopyAssignment)
             EXPECT_EQ(stack.Top(), copy_stack.Top());
             stack.Pop();
             copy_stack.Pop();
+        }
+    }
+}
+
+TEST(BasicTest, SelfCopyAssignment)
+{
+    {
+        StackDuplicateFifo<int> a;
+        auto& r = a;
+        a = r;
+        EXPECT_EQ(a.Size(), 0);
+        EXPECT_EQ(a.Empty(), true);
+    }
+    {
+        std::vector<int> expected = {0, 1, 2, 3, 4};
+        StackDuplicateFifo<int> a;
+        for (int i = 0; i < 5; ++i)
+        {
+            a.Push(i);
+        }
+        auto& r = a;
+        a = r;
+        EXPECT_EQ(a.Size(), 5);
+        EXPECT_EQ(a.Empty(), false);
+
+        while (!expected.empty())
+        {
+            EXPECT_EQ(a.Size(), expected.size());
+            EXPECT_EQ(a.Top(), expected.back());
+            a.Pop();
+            expected.pop_back();
         }
     }
 }


### PR DESCRIPTION
Стек представлен `std::deque`. Количество повторяющихся элементов хранится в `std::unordered_map`. Суть реализации в следующем:
- если вершина стека имеет повторы в стеке, то при удалении, уменьшается счетчик количество повторов в хеш-таблице, уменьшается размер `m_size`, но вершина стека не удаляется до тех пор, пока текущий элемент не последний.
- после обнуления счетчика из хэш-таблицы полностью удаляется элемент.
- фактически удаления повторяющихся более глубоких элементов не происходит до тех пор, пока мы не дойдем до данного элемента. Более глубокие элементы являются невалидными.
- невалидность определяется отсутствием данного элемента в хэш-таблице
- если на вершине невалидный эдемент, то при вызове `top()` приходится удалять невалидный элемент.
- невалидные элементы также удаляются при вызове `pop()`
- пока хешер для пользовательского класса не прокидывается (надо доработать)

Возможности изменения реализации:
- возможно использовать `std::vector` вместо `std::deque`
- возможно заменить `std::unordered_map` на `std::map` - получив O(log(n)) вместо амортизированной O(1), чтобы не писать хэшер для пользовательского класса
- если пользовательские элементы могут быть == при сравнение через оператор, но фактически несут какую-то дополнительную информацию, а метод `top()` должен снимать самый глубокий элемент (а `pop()` удалять самый глубокий), то можно по ключу хранить очередь из указателей, итераторов (для `std::deque`) на элемент в контейнере, тогда можно будет отдавать самый глубокий (удаление оставить по текущему принципу)
- если необходимо избавляться от самого глубокого элемента сразу, чтобы сразу освобождать память и не копить невалидные элементы (при определенных сценариях использования они могут занимать много неиспользуемого места), то заменить деку на `std::list`, чтобы за О(1) удалять из середины, а в ассоциативном контейнере хранить очередь из указателей (итераторов). 

В тестах `RandomFilled` и `Stress` для проверки работы контейнера производится сравнение с медленной версией контейнера `SlowStackDuplicateFifo` - основанного `std::list` и линейном поиске глубокого дубликата при каждом вызове `pop()`